### PR TITLE
Remove checks for Windows 7 VS requirements

### DIFF
--- a/addglyph/main.py
+++ b/addglyph/main.py
@@ -253,6 +253,18 @@ def addglyph(
 
         vs_in_font.add(seq)
 
+    os2 = cast("O_S_2f_2.table_O_S_2f_2", ttf["OS/2"])
+
+    old_uniranges: set[int] = os2.getUnicodeRanges()
+    new_uniranges: set[int] = os2.recalcUnicodeRanges(ttf)
+    # Retain old uniranges
+    os2.setUnicodeRanges(old_uniranges | new_uniranges)
+
+    old_codepages: set[int] = os2.getCodePageRanges()
+    new_codepages: set[int] = os2.recalcCodePageRanges(ttf)
+    # Retain old codepages
+    os2.setCodePageRanges(old_codepages | new_codepages)
+
     if vs:
         check_vs(ttf)
 

--- a/usage.txt
+++ b/usage.txt
@@ -97,10 +97,6 @@ VSファイルは次のような形式のテキストファイルで、フォン
 「INFO:addglyph.main:added: U+xxxx U+yyyy as non-default」
 　…非デフォルトVS <U+xxxx U+yyyy>をフォントに追加した
 「INFO:addglyph.main:already in font: U+xxxx U+yyyy」…<U+xxxx U+yyyy>は既にフォントに入っている
-「INFO:addglyph.main:U+0020 should be added for VS to work on Windows 7」
-　…Windows 7でVSが機能するためにはU+0020がフォントに無いといけないが、無い
-「INFO:addglyph.main:at least one non-BMP character should be added for VS to work on Windows 7」
-　…Windows 7でVSが機能するためにはU+10000以上の文字が1つ以上フォントに無いといけないが、1つも無い
 「INFO:addglyph.main:### glyphs added!」…###個のグリフを追加した
 「INFO:addglyph.main:saving...」…保存中
 「INFO:addglyph.main:reordering...」…フォントファイル内のテーブルを並び替え中


### PR DESCRIPTION
If the existing font does not meet the requirements for VS to be rendered on Windows 7:

- Do not print info messages about it
- Do not try to fix it (by modifying `cmap` or `GSUB` tables)

However, add glyphs in a way that does not cause the existing font to fail the requirements.